### PR TITLE
Allow HTML tags in link text

### DIFF
--- a/lib/wai-website-plugin.rb
+++ b/lib/wai-website-plugin.rb
@@ -65,7 +65,7 @@ def transform(document, inenglishtext)
       end
     end
 
-    document.content.gsub!(/<<([^>>]+?)>>/i) do |match|
+    document.content.gsub!(/<<(.+?)>>/i) do |match|
         '[' + Regexp.last_match[1] +']'
     end
 

--- a/wai-website-plugin.gemspec
+++ b/wai-website-plugin.gemspec
@@ -2,8 +2,8 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "wai-website-plugin"
-  spec.version       = "0.1.2"
-  spec.authors       = ["Eric Eggert"]
+  spec.version       = "0.1.3"
+  spec.authors       = ["Eric Eggert","Kevin White","Rémi Bétin"]
   spec.email         = ["ee@w3.org"]
 
   spec.summary       = ""


### PR DESCRIPTION
Resolves https://github.com/w3c/wai-website/issues/481 (and also addresses https://github.com/w3c/wai-std-gl-overview/issues/21)

## Description of the problem

When link text is enclosed in double square brackets, `[[link_text]](/url/)`, we want the plugin to replace it with the title of the target resource, in the same language as the current page. When the target page has not been translated yet, we want the plugin to keep the link text that is between brackets.

That is generally working, but sometimes, translators prefer to keep part of the link text in English. In this case, they add `<span lang="en"></span>` markup in the link text.

The plugin does not handle this case correctly.

### Example raised in https://github.com/w3c/wai-website/issues/481

`[[Χρησιμοποιώντας Υλικά του <span lang='en'>WAI</span>: Άδεια Χρήσης με Απόδοση (<span lang='en'>Attribution</span>)]](/about/using-wai-material/)`

is rendered as:

`Μπορείτε να χρησιμοποιήσετε αυτό το βίντεο εάν συμπεριλάβετε έναν σύνδεσμο προς αυτήν τη σελίδα. Περισσότερες πληροφορίες διατίθενται στο «Χρησιμοποιώντας Υλικά του WAI: Άδεια Χρήσης με Απόδοση (Attribution) (στα Αγγλικά)»(/WAI/about/using-wai-material/){: hreflang=”en”}.`

Instead of:

<a href="/WAI/about/using-wai-material/" hreflang="en">Χρησιμοποιώντας Υλικά του <span lang='en'>WAI</span>: Άδεια Χρήσης με Απόδοση (<span lang='en'>Attribution</span>) (στα Αγγλικά)</a>

### Technical side of the problem

Double brackets links are currently processed in 2 steps:

- Step 1: `[[link_text]](/url/#fragment)`
  is turned into 
  `<<link_text ("in English" in the target language)>>(/WAI/url/#fragment){: hreflang="en"}`

  https://github.com/w3c/wai-website-plugin/blob/4392f43963343da12923e6167c26645809ab5bee/lib/wai-website-plugin.rb#L31-L39

- Step 2: `<<link_text ("in English" in the target language)>>(/WAI/url/#fragment){: hreflang="en"}`
  is expected to be turned into 
  `[link_text ("in English" in the target language)](/WAI/url/#fragment){: hreflang="en"}`

  https://github.com/w3c/wai-website-plugin/blob/4392f43963343da12923e6167c26645809ab5bee/lib/wai-website-plugin.rb#L68-L70

Problem: the regular expression `/<<([^>>]+?)>>/i` tries to extract the link text but stops at first `>` character (the second `>` is superfluous). Including at first HTML tag.

### Solution

[In Progress]